### PR TITLE
feat: add support for npx execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,13 @@
 {
-  "name": "js-sandbox-mcp",
+  "name": "node-code-sandbox-mcp",
   "version": "0.1.0",
   "type": "module",
+  "bin": {
+    "node-code-sandbox-mcp": "dist/server.js"
+  },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "dev": "tsx src/server.ts",
     "dev:evals": "tsx evals/index.ts",
@@ -11,7 +17,8 @@
     "test:coverage": "vitest --coverage",
     "inspector": "npx @modelcontextprotocol/inspector npm run dev",
     "lint": "eslint . --ext .ts --report-unused-disable-directives --max-warnings 0",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.10.2",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import {
   McpServer,
   ResourceTemplate,


### PR DESCRIPTION
## Issue Link
- [x] Issue #16 

## Motivation
Allow running the MCP server using `npx` 🚀 

### Description
* Renamed the package from `js-sandbox-mcp` to `node-code-sandbox-mcp` to align with the GitHub repository name. 
* Added a `bin` field to define the executable entry point (`dist/server.js`).
* Added `files` field to include only the `dist` directory in the published package.
* Added a `prepublishOnly` script to ensure the build process runs before publishing the package.

* `src/server.ts`: Added a shebang (`#!/usr/bin/env node`) to make the server script executable directly from the command line.


### Example in VSCode (when will be available on NPM, atm workspace directory path is needed)
```json
"mcp": {
    "servers": {
      "node-code-sandbox-mcp": {
        "type": "stdio",
        "command": "npx",
        "args": [
          "-y",
          "node-code-sandbox-mcp"
        ],
        "env": {
          "FILES_DIR": "/path/to/your/dir"
        },
      }
    }
  }
```

