### PR TITLE
Improve`getSnapshot` utility fn to use `glob` async generator and exclude pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dist"
   ],
   "scripts": {
-    "dev": "node src/server.ts",
+    "dev": "node --env-file .env --watch src/server.ts",
     "dev:evals": "node evals/index.ts",
     "build": "rimraf dist && tsc -p tsconfig.build.json && shx chmod +x dist/*.js",
     "start": "node dist/server.js",

--- a/src/snapshotUtils.ts
+++ b/src/snapshotUtils.ts
@@ -1,9 +1,11 @@
-import * as fs from 'fs';
-import * as path from 'path';
-import { type McpContent, textContent } from './types.ts';
+import path from 'node:path';
+import { glob, stat, readFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+
 import mime from 'mime-types';
-import { pathToFileURL } from 'url';
+
 import { getFilesDir } from './runUtils.ts';
+import { type McpContent, textContent } from './types.ts';
 import { isRunningInDocker } from './utils.ts';
 
 type ChangeType = 'created' | 'updated' | 'deleted';
@@ -22,38 +24,34 @@ export const getMountPointDir = () => {
   return getFilesDir();
 };
 
-export function getSnapshot(dir: string): FileSnapshot {
+export async function getSnapshot(dir: string): Promise<FileSnapshot> {
   const snapshot: FileSnapshot = {};
 
-  function walk(currentPath: string) {
-    const entries = fs.readdirSync(currentPath, { withFileTypes: true });
+  const executor = glob('**/*', {
+    cwd: dir,
+    withFileTypes: true,
+    exclude: ['.git', 'node_modules'],
+  });
 
-    for (const entry of entries) {
-      const fullPath = path.join(currentPath, entry.name);
-      const stats = fs.statSync(fullPath);
-
-      snapshot[fullPath] = {
-        mtimeMs: stats.mtimeMs,
-        isDirectory: entry.isDirectory(),
-      };
-
-      if (entry.isDirectory()) {
-        walk(fullPath);
-      }
-    }
+  for await (const entry of executor) {
+    const fullPath = path.join(entry.parentPath, entry.name);
+    const stats = await stat(fullPath);
+    snapshot[fullPath] = {
+      mtimeMs: stats.mtimeMs,
+      isDirectory: entry.isDirectory(),
+    };
   }
 
-  walk(dir);
   return snapshot;
 }
 
-export function detectChanges(
+export async function detectChanges(
   prevSnapshot: FileSnapshot,
   dir: string,
   sinceTimeMs: number
-): Change[] {
+): Promise<Change[]> {
   const changes: Change[] = [];
-  const currentSnapshot = getSnapshot(dir);
+  const currentSnapshot = await getSnapshot(dir);
 
   const allPaths = new Set([
     ...Object.keys(prevSnapshot),
@@ -118,7 +116,7 @@ export async function changesToMcpContent(
     const mimeType = mime.lookup(change.path) || 'application/octet-stream';
 
     if (imageTypes.has(mimeType)) {
-      const b64 = await fs.promises.readFile(change.path, {
+      const b64 = await readFile(change.path, {
         encoding: 'base64',
       });
       contents.push({

--- a/src/tools/runJs.ts
+++ b/src/tools/runJs.ts
@@ -73,7 +73,7 @@ export default async function runJs({
 
   // Generate snapshot of the workspace
   const snapshotStartTime = Date.now();
-  const snapshot = getSnapshot(getMountPointDir());
+  const snapshot = await getSnapshot(getMountPointDir());
 
   if (listenOnPort) {
     const installStart = Date.now();
@@ -114,9 +114,13 @@ export default async function runJs({
 
   // Detect the file changed during the execution of the tool in the mounted workspace
   // and report the changes to the user
-  const extractedContents = await changesToMcpContent(
-    detectChanges(snapshot, getMountPointDir(), snapshotStartTime)
+  const changes = await detectChanges(
+    snapshot,
+    getMountPointDir(),
+    snapshotStartTime
   );
+
+  const extractedContents = await changesToMcpContent(changes);
   localWorkspace.removeCallback();
 
   return {

--- a/src/tools/runJsEphemeral.ts
+++ b/src/tools/runJsEphemeral.ts
@@ -96,7 +96,7 @@ export default async function runJsEphemeral({
 
     // Generate snapshot of the workspace
     const snapshotStartTime = Date.now();
-    const snapshot = getSnapshot(getMountPointDir());
+    const snapshot = await getSnapshot(getMountPointDir());
 
     // Run install and script inside container
     const installCmd = `npm install --omit=dev --prefer-offline --no-audit --loglevel=error`;
@@ -119,9 +119,13 @@ export default async function runJsEphemeral({
 
     // Detect the file changed during the execution of the tool in the mounted workspace
     // and report the changes to the user
-    const extractedContents = await changesToMcpContent(
-      detectChanges(snapshot, getMountPointDir(), snapshotStartTime)
+    const changes = await detectChanges(
+      snapshot,
+      getMountPointDir(),
+      snapshotStartTime
     );
+
+    const extractedContents = await changesToMcpContent(changes);
 
     return {
       content: [

--- a/test/snapshotUtils.test.ts
+++ b/test/snapshotUtils.test.ts
@@ -23,7 +23,7 @@ describe('Filesystem snapshot and change detection', () => {
     tmpDir.removeCallback();
   });
 
-  it('getSnapshot returns correct structure for files and directories', () => {
+  it('getSnapshot returns correct structure for files and directories', async () => {
     const file1 = path.join(tmpDir.name, 'file1.txt');
     const subDir = path.join(tmpDir.name, 'sub');
     const file2 = path.join(subDir, 'file2.txt');
@@ -32,7 +32,7 @@ describe('Filesystem snapshot and change detection', () => {
     createDir(subDir);
     createFile(file2, 'World');
 
-    const snapshot = getSnapshot(tmpDir.name);
+    const snapshot = await getSnapshot(tmpDir.name);
 
     expect(Object.keys(snapshot)).toContain(file1);
     expect(Object.keys(snapshot)).toContain(subDir);
@@ -43,13 +43,13 @@ describe('Filesystem snapshot and change detection', () => {
     expect(snapshot[file2].isDirectory).toBe(false);
   });
 
-  it('detectChanges detects created files', () => {
-    const initialSnapshot = getSnapshot(tmpDir.name);
+  it('detectChanges detects created files', async () => {
+    const initialSnapshot = await getSnapshot(tmpDir.name);
 
     const newFile = path.join(tmpDir.name, 'newFile.txt');
     createFile(newFile, 'New content');
 
-    const changes = detectChanges(
+    const changes = await detectChanges(
       initialSnapshot,
       tmpDir.name,
       Date.now() - 1000
@@ -64,14 +64,14 @@ describe('Filesystem snapshot and change detection', () => {
     ]);
   });
 
-  it('detectChanges detects deleted files', () => {
+  it('detectChanges detects deleted files', async () => {
     const fileToDelete = path.join(tmpDir.name, 'toDelete.txt');
     createFile(fileToDelete, 'To be deleted');
 
-    const snapshotBeforeDelete = getSnapshot(tmpDir.name);
+    const snapshotBeforeDelete = await getSnapshot(tmpDir.name);
     fs.unlinkSync(fileToDelete);
 
-    const changes = detectChanges(
+    const changes = await detectChanges(
       snapshotBeforeDelete,
       tmpDir.name,
       Date.now() - 1000
@@ -90,13 +90,17 @@ describe('Filesystem snapshot and change detection', () => {
     const fileToUpdate = path.join(tmpDir.name, 'update.txt');
     createFile(fileToUpdate, 'Original');
 
-    const snapshot = getSnapshot(tmpDir.name);
+    const snapshot = await getSnapshot(tmpDir.name);
 
     // Wait to ensure mtimeMs changes
     await new Promise((resolve) => setTimeout(resolve, 20));
     fs.writeFileSync(fileToUpdate, 'Updated');
 
-    const changes = detectChanges(snapshot, tmpDir.name, Date.now() - 1000);
+    const changes = await detectChanges(
+      snapshot,
+      tmpDir.name,
+      Date.now() - 1000
+    );
 
     expect(changes).toEqual([
       {


### PR DESCRIPTION
This pull request refactors the filesystem snapshot and changes detection to use asynchronous file system operations, improving performance and ignoring "blackholes" folders like `node_modules` and `.git`. It also updates related tests and scripts to accommodate these changes.

That's a first improvement step for the issue #42.

### Refactoring for Asynchronous File Operations:

* [`src/snapshotUtils.ts`](diffhunk://#diff-4cf86a3339c4ca91960ff8be00c36d9a3ee621c30eeae467b04b3677c17b4db9L25-R54): Refactored `getSnapshot` and `detectChanges` functions to use asynchronous file system APIs and the `glob` async generator avoiding bottlenecks using sync op. [[1]](diffhunk://#diff-4cf86a3339c4ca91960ff8be00c36d9a3ee621c30eeae467b04b3677c17b4db9L25-R54) [[2]](diffhunk://#diff-4cf86a3339c4ca91960ff8be00c36d9a3ee621c30eeae467b04b3677c17b4db9L121-R119)
* `src/tools/runJs.ts` and `src/tools/runJsEphemeral.ts`: Updated calls to `getSnapshot` and `detectChanges` to handle their new asynchronous nature. [[1]](diffhunk://#diff-5cdd0e6510b994983f2adbfda1995067535b1139cb186f7cd1bb539073e36458L76-R76) [[2]](diffhunk://#diff-5cdd0e6510b994983f2adbfda1995067535b1139cb186f7cd1bb539073e36458L117-R123) [[3]](diffhunk://#diff-ac2f4f30ac941da4d12b1715bb1024cfeec398ecb950d11c7c444d9fe4ec44d5L99-R99) [[4]](diffhunk://#diff-ac2f4f30ac941da4d12b1715bb1024cfeec398ecb950d11c7c444d9fe4ec44d5L122-R129)

### Updates to Tests:

* [`test/snapshotUtils.test.ts`](diffhunk://#diff-5970c5aa29c5f3c23a4b702e493c5326a197f7d4f4f5128189653fa56b178365L26-R26): Updated all test cases for `getSnapshot` and `detectChanges` to use `await` due to their new asynchronous implementations. [[1]](diffhunk://#diff-5970c5aa29c5f3c23a4b702e493c5326a197f7d4f4f5128189653fa56b178365L26-R26) [[2]](diffhunk://#diff-5970c5aa29c5f3c23a4b702e493c5326a197f7d4f4f5128189653fa56b178365L35-R35) [[3]](diffhunk://#diff-5970c5aa29c5f3c23a4b702e493c5326a197f7d4f4f5128189653fa56b178365L46-R52) [[4]](diffhunk://#diff-5970c5aa29c5f3c23a4b702e493c5326a197f7d4f4f5128189653fa56b178365L67-R74) [[5]](diffhunk://#diff-5970c5aa29c5f3c23a4b702e493c5326a197f7d4f4f5128189653fa56b178365L93-R103)

### Chore changes:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L12-R12): Enhanced the `dev` script to include `.env` file loading and watch mode.