### PR TITLE
skip npm install if no dependencies are provided

### DIFF
--- a/src/tools/runJs.ts
+++ b/src/tools/runJs.ts
@@ -76,15 +76,20 @@ export default async function runJs({
   const snapshot = getSnapshot(getMountPointDir());
 
   if (listenOnPort) {
-    const installStart = Date.now();
-    const installOutput = execSync(
-      `docker exec ${container_id} /bin/sh -c ${JSON.stringify(
-        `npm install --omit=dev --prefer-offline --no-audit --loglevel=error`
-      )}`,
-      { encoding: 'utf8' }
-    );
-    telemetry.installTimeMs = Date.now() - installStart;
-    telemetry.installOutput = installOutput;
+    if (dependencies.length > 0) {
+      const installStart = Date.now();
+      const installOutput = execSync(
+        `docker exec ${container_id} /bin/sh -c ${JSON.stringify(
+          `npm install --omit=dev --prefer-offline --no-audit --loglevel=error`
+        )}`,
+        { encoding: 'utf8' }
+      );
+      telemetry.installTimeMs = Date.now() - installStart;
+      telemetry.installOutput = installOutput;
+    } else {
+      telemetry.installTimeMs = 0;
+      telemetry.installOutput = 'Skipped npm install (no dependencies)';
+    }
 
     const runScript = `nohup node index.js > output.log 2>&1 &`;
     execSync(
@@ -94,14 +99,19 @@ export default async function runJs({
     await waitForPortHttp(listenOnPort);
     rawOutput = `Server started in background; logs at /output.log`;
   } else {
-    const installStart = Date.now();
-    const fullCmd = `npm install --omit=dev --prefer-offline --no-audit --loglevel=error`;
-    const installOutput = execSync(
-      `docker exec ${container_id} /bin/sh -c ${JSON.stringify(fullCmd)}`,
-      { encoding: 'utf8' }
-    );
-    telemetry.installTimeMs = Date.now() - installStart;
-    telemetry.installOutput = installOutput;
+    if (dependencies.length > 0) {
+      const installStart = Date.now();
+      const fullCmd = `npm install --omit=dev --prefer-offline --no-audit --loglevel=error`;
+      const installOutput = execSync(
+        `docker exec ${container_id} /bin/sh -c ${JSON.stringify(fullCmd)}`,
+        { encoding: 'utf8' }
+      );
+      telemetry.installTimeMs = Date.now() - installStart;
+      telemetry.installOutput = installOutput;
+    } else {
+      telemetry.installTimeMs = 0;
+      telemetry.installOutput = 'Skipped npm install (no dependencies)';
+    }
 
     const runStart = Date.now();
     const runCmd = `node index.js`;

--- a/src/tools/runJsEphemeral.ts
+++ b/src/tools/runJsEphemeral.ts
@@ -102,13 +102,18 @@ export default async function runJsEphemeral({
     const installCmd = `npm install --omit=dev --prefer-offline --no-audit --loglevel=error`;
     const runCmd = `node index.js`;
 
-    const installStart = Date.now();
-    const installOutput = execSync(
-      `docker exec ${containerId} /bin/sh -c ${JSON.stringify(installCmd)}`,
-      { encoding: 'utf8' }
-    );
-    telemetry.installTimeMs = Date.now() - installStart;
-    telemetry.installOutput = installOutput;
+    if (dependencies.length > 0) {
+      const installStart = Date.now();
+      const installOutput = execSync(
+        `docker exec ${containerId} /bin/sh -c ${JSON.stringify(installCmd)}`,
+        { encoding: 'utf8' }
+      );
+      telemetry.installTimeMs = Date.now() - installStart;
+      telemetry.installOutput = installOutput;
+    } else {
+      telemetry.installTimeMs = 0;
+      telemetry.installOutput = 'Skipped npm install (no dependencies)';
+    }
 
     const runStart = Date.now();
     const rawOutput = execSync(

--- a/test/runJs.test.ts
+++ b/test/runJs.test.ts
@@ -123,6 +123,30 @@ describe('runJs basic execution', () => {
     }
   });
 
+  it('should skip npm install if no dependencies are provided', async () => {
+    const result = await runJs({
+      container_id: containerId,
+      code: "console.log('No deps');",
+      dependencies: [],
+    });
+
+    const telemetryItem = result.content.find(
+      (c) => c.type === 'text' && c.text.startsWith('Telemetry:')
+    );
+
+    expect(telemetryItem).toBeDefined();
+    if (telemetryItem?.type === 'text') {
+      const telemetry = JSON.parse(
+        telemetryItem.text.replace('Telemetry:\n', '')
+      );
+
+      expect(telemetry.installTimeMs).toBe(0);
+      expect(telemetry.installOutput).toBe(
+        'Skipped npm install (no dependencies)'
+      );
+    }
+  });
+
   it('should install lodash and use it', async () => {
     const result = await runJs({
       container_id: containerId,

--- a/test/runJsEphemeral.test.ts
+++ b/test/runJsEphemeral.test.ts
@@ -94,6 +94,29 @@ describe('runJsEphemeral', () => {
       }
     });
 
+    it('should skip npm install if no dependencies are provided', async () => {
+      const result = await runJsEphemeral({
+        code: "console.log('No deps');",
+        dependencies: [],
+      });
+
+      const telemetryItem = result.content.find(
+        (c) => c.type === 'text' && c.text.startsWith('Telemetry:')
+      );
+
+      expect(telemetryItem).toBeDefined();
+      if (telemetryItem?.type === 'text') {
+        const telemetry = JSON.parse(
+          telemetryItem.text.replace('Telemetry:\n', '')
+        );
+
+        expect(telemetry.installTimeMs).toBe(0);
+        expect(telemetry.installOutput).toBe(
+          'Skipped npm install (no dependencies)'
+        );
+      }
+    });
+
     it('should generate a valid QR code resource', async () => {
       const result = await runJsEphemeral({
         code: `


### PR DESCRIPTION
Both `run_js` and `run_js_ephemeral` now skip the npm install step when the`dependencies` array is empty or undefined. 
This avoids unnecessary delays during executions that do not require external packages.

Also added unit tests to assert that:
- install is skipped when dependencies are empty
- telemetry reflects the correct install output