### PR TITLE
chore: add `mcp.json` vscode workspace config

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,20 @@
+{
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "id_files_dir_node_code_sandbox_mcp",
+      "description": "Files directory for the Node Code Sandbox MCP",
+      "password": false
+    }
+  ],
+  "servers": {
+    "node-code-sandbox-mcp (dev)": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["${workspaceFolder}/src/server.ts"],
+      "env": {
+        "FILES_DIR": "${input:id_files_dir_node_code_sandbox_mcp}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Add `mcp.json` for GitHub Copilot Agent Mode Support in VSCode**

With the latest addition of [MCP server support in Visual Studio Code](https://code.visualstudio.com/docs/copilot/chat/mcp-servers), this PR introduces a `mcp.json` configuration file to the development environment. This enables seamless integration with GitHub Copilot's Agent Mode by allowing developers and contributors to connect to the MCP server without additional setup.

Added also the `inputs` field, which prompts the user on the first server start and securely stores the values in the editor. This makes the configuration both secure and sharable.
